### PR TITLE
Add attr_value support to shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,30 @@ which renders to
 </script>
 ~~~
 
+#### Lambda shortcuts
+
+You can define custom shortcuts using lambdas.
+
+In this example we add `~` to create a shortcut with a special processing (adding a prefix) for the class attribute.
+
+~~~ ruby
+Slim::Engine.set_options shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+~~~
+
+We can use it in Slim code like this
+
+~~~ slim
+h1~title Hello
+~text~question How are you?
+~~~
+
+which renders to
+
+~~~ html
+<h1 class="styled-title">Hello</h1>
+<div class="styled-text styled-question">How are you?</div>
+~~~
+
 #### ID shortcut `#` and class shortcut `.`
 
 You can specify the `id` and `class` attributes in the following shortcut form

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -55,9 +55,9 @@ module Slim
         @tab_re = "\t"
         @tab = ' '
       end
-      @tag_shortcut, @attr_shortcut, @additional_attrs = {}, {}, {}
+      @tag_shortcut, @attr_shortcut, @additional_attrs, @attr_value = {}, {}, {}, {}
       options[:shortcut].each do |k,v|
-        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs]).empty?
+        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs, :attr_value]).empty?
         @tag_shortcut[k] = v[:tag] || options[:default_tag]
         if v.include?(:attr) || v.include?(:additional_attrs)
           raise ArgumentError, 'You can only use special characters for attribute shortcuts' if k =~ /(\p{Word}|-)/
@@ -67,6 +67,9 @@ module Slim
         end
         if v.include?(:additional_attrs)
           @additional_attrs[k] = v[:additional_attrs]
+        end
+        if v.include?(:attr_value)
+          @attr_value[k] = v[:attr_value]
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
@@ -336,7 +339,14 @@ module Slim
         # The class/id attribute is :static instead of :slim :interpolate,
         # because we don't want text interpolation in .class or #id shortcut
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
-        shortcut.each {|a| attributes << [:html, :attr, a, [:static, $2]] }
+
+        if @attr_value[$1]
+          value = [:dynamic, @attr_value[$1].call($2)]
+        else
+          value = [:static, $2]
+        end
+
+        shortcut.each {|a| attributes << [:html, :attr, a, value] }
         if additional_attr_pairs = @additional_attrs[$1]
           additional_attr_pairs.each do |k,v|
             attributes << [:html, :attr, k.to_s, [:static, v]]

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -55,21 +55,22 @@ module Slim
         @tab_re = "\t"
         @tab = ' '
       end
-      @tag_shortcut, @attr_shortcut, @additional_attrs, @attr_value = {}, {}, {}, {}
+      @tag_shortcut, @attr_shortcut, @additional_attrs = {}, {}, {}
       options[:shortcut].each do |k,v|
-        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs, :attr_value]).empty?
+        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs]).empty?
         @tag_shortcut[k] = v[:tag] || options[:default_tag]
         if v.include?(:attr) || v.include?(:additional_attrs)
           raise ArgumentError, 'You can only use special characters for attribute shortcuts' if k =~ /(\p{Word}|-)/
         end
         if v.include?(:attr)
-          @attr_shortcut[k] = [v[:attr]].flatten
+          if v[:attr].is_a?(Proc)
+            @attr_shortcut[k] = v[:attr]
+          else
+            @attr_shortcut[k] = [v[:attr]].flatten
+          end
         end
         if v.include?(:additional_attrs)
           @additional_attrs[k] = v[:additional_attrs]
-        end
-        if v.include?(:attr_value)
-          @attr_value[k] = v[:attr_value]
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
@@ -340,13 +341,14 @@ module Slim
         # because we don't want text interpolation in .class or #id shortcut
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
 
-        if @attr_value[$1]
-          value = [:dynamic, @attr_value[$1].call($2)]
+        if shortcut.is_a?(Proc)
+          value = shortcut.call($2)
+          attributes << [:html, :attr, value[0], [:dynamic, value[1]]]
         else
           value = [:static, $2]
+          shortcut.each {|a| attributes << [:html, :attr, a, value] }
         end
 
-        shortcut.each {|a| attributes << [:html, :attr, a, value] }
         if additional_attr_pairs = @additional_attrs[$1]
           additional_attr_pairs.each do |k,v|
             attributes << [:html, :attr, k.to_s, [:static, v]]

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -115,6 +115,30 @@ h1#title This is my title
                 source, shortcut: {'^' => {tag: 'script', attr: 'data-binding', additional_attrs: { type: "application/json" }}}
   end
 
+  def test_render_with_custom_lambda_shortcut
+    source = %q{
+~foo Hello
+}
+    assert_html '<div class="styled-foo">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+  end
+
+  def test_render_with_custom_lambda_shortcut_and_multiple_values
+    source = %q{
+~foo~bar Hello
+}
+    assert_html '<div class="styled-foo styled-bar">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+  end
+
+#   def test_render_with_custom_lambda_shortcut_and_existing_class
+#     source = %q{
+# ~foo.baz Hello
+# }
+#     assert_html '<div class="styled-foo baz">Hello</div>',
+#                 source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+#   end
+
   def test_render_with_text_block
     source = %q{
 p


### PR DESCRIPTION
Related discussion: https://github.com/ViewComponent/view_component/pull/677#issuecomment-817023300

**NOTE:** This is a quick & dirty test! It should be refactored and tested before opening a PR against upstream.

This creates an `attr_value` param for shortcuts. You can pass it a Proc that will be called when the tag is parsed.

```rb
Slim::Parser.options[:shortcut].update({
  '~' => { attr: "class", attr_value: ->(v) { "styles['#{v}']" } }
})
```

Then in your slim template you can do:

```slim
~text Lorem ipsum
/ <div class="Styled_6c266_text">Lorem ipsum</div>

p~text.is-big LOREM IPSUM
/ <p class="Styled_6c266_text is-big">LOREM IPSUM</p>
```